### PR TITLE
git.io->cloudposse.tools update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 # List of targets the `readme` target should call before generating the readme
 export README_DEPS ?= docs/targets.md docs/terraform.md
 
--include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+-include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
 
 ## Lint terraform code
 lint:


### PR DESCRIPTION
## what and why 
Change all references to `git.io/build-harness` into `cloudposse.tools/build-harness`, since `git.io` redirects will stop working on April 29th, 2022.

## References
- DEV-143