### PR TITLE
chore: (workflow): change to not automatically release releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -19,7 +19,7 @@ jobs:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         with:
-          publish: ${{ !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
+          publish: false
           prerelease: false
           config-name: auto-release.yml
         env:


### PR DESCRIPTION
## what
* Update auto-releaser to create draft releases so multiple changes can be bundled into a release
 
## why
* Several PRs will need to be combined into a "release"